### PR TITLE
Split core, transactions extension 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,21 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [v0.2.0] - 2026-10-14
 
-- Split Catalogs Client into core client and transaction client
+### Added
+
+- Split Catalogs extension into two classes:
+  - `CatalogsExtension`: Read-only discovery endpoints
+  - `CatalogsTransactionExtension`: Write operations (POST, PUT, DELETE)
+- Dynamic conformance class registration via `app.state` for seamless extension composition
+
+### Changed
+
+- **BREAKING**: `CatalogsExtension` no longer accepts `enable_transactions` parameter. Use `CatalogsTransactionExtension` separately for write operations.
+- Conformance classes are now explicitly passed during initialization, following standard STAC FastAPI extension patterns.
+
+### Fixed
+
+- Pinned `httpx<0.28` to prevent URL parsing breaking changes in httpx 0.28.0+
 
 ## [v0.1.3] - 2026-04-10
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 
+## [v0.2.0] - 2026-10-14
+
+- Split Catalogs Client into core client and transaction client
+
 ## [v0.1.3] - 2026-04-10
 
 ### Updated
@@ -65,7 +69,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 	with the Black profile.
 
 
-[Unreleased]: https://github.com/StacLabs/stac-fastapi-catalogs-extension/compare/v0.1.2...main
+[Unreleased]: https://github.com/StacLabs/stac-fastapi-catalogs-extension/compare/v0.2.0...main
+[v0.2.0]: https://github.com/StacLabs/stac-fastapi-catalogs-extension/compare/v0.1.2...v0.2.0
 [v0.1.2]: https://github.com/StacLabs/stac-fastapi-catalogs-extension/compare/v0.1.1...v0.1.2
 [v0.1.1]: https://github.com/StacLabs/stac-fastapi-catalogs-extension/compare/v0.1.0...v0.1.1
 [v0.1.0]: https://github.com/StacLabs/stac-fastapi-catalogs-extension/releases/tag/v0.1.0

--- a/README.md
+++ b/README.md
@@ -101,7 +101,9 @@ the AsyncBaseCatalogsClient contract.
 
 ## What this package provides
 
-- A STAC FastAPI extension class: CatalogsExtension
+- Two STAC FastAPI extension classes:
+  - `CatalogsExtension`: Read-only discovery endpoints for catalogs
+  - `CatalogsTransactionExtension`: Write operations (POST, PUT, DELETE) for catalog management
 - Request/response models for catalogs and children APIs
 - An abstract client contract: AsyncBaseCatalogsClient
 
@@ -119,13 +121,19 @@ pip install stac-fastapi-catalogs-extension
 
 In your deployment app.py (for example in
 stac-fastapi-elasticsearch-opensearch), instantiate StacApi with
-CatalogsExtension and pass an implementation of AsyncBaseCatalogsClient.
+CatalogsExtension and optionally CatalogsTransactionExtension, passing an
+implementation of AsyncBaseCatalogsClient.
+
+### Read-only deployment (discovery only)
 
 ```python
 from stac_fastapi.api.app import StacApi
 from stac_fastapi.types.config import ApiSettings
 
-from multi_tenant_catalogs import CatalogsExtension
+from stac_fastapi_catalogs_extension import (
+    CatalogsExtension,
+    CATALOGS_CORE_CONFORMANCE,
+)
 from my_project.catalogs_client import CatalogsClient
 from my_project.core_client import CoreClient
 
@@ -141,9 +149,50 @@ api = StacApi(
     extensions=[
         CatalogsExtension(
             client=catalogs_client,
-            enable_transactions=True,
+            conformance_classes=list(CATALOGS_CORE_CONFORMANCE),
             settings=settings.model_dump(),
         )
+    ],
+)
+
+app = api.app
+```
+
+### With transaction support (read and write)
+
+```python
+from stac_fastapi.api.app import StacApi
+from stac_fastapi.types.config import ApiSettings
+
+from stac_fastapi_catalogs_extension import (
+    CatalogsExtension,
+    CatalogsTransactionExtension,
+    CATALOGS_CORE_CONFORMANCE,
+    CATALOGS_TRANSACTION_CONFORMANCE,
+)
+from my_project.catalogs_client import CatalogsClient
+from my_project.core_client import CoreClient
+
+
+settings = ApiSettings()
+
+core_client = CoreClient(...)
+catalogs_client = CatalogsClient(...)
+
+api = StacApi(
+    settings=settings,
+    client=core_client,
+    extensions=[
+        CatalogsExtension(
+            client=catalogs_client,
+            conformance_classes=list(CATALOGS_CORE_CONFORMANCE)
+            + list(CATALOGS_TRANSACTION_CONFORMANCE),
+            settings=settings.model_dump(),
+        ),
+        CatalogsTransactionExtension(
+            client=catalogs_client,
+            settings=settings.model_dump(),
+        ),
     ],
 )
 
@@ -162,6 +211,10 @@ required async methods, including:
 - delete_catalog
 - get_catalog_collections
 - create_catalog_collection
+- get_catalog_collection
+- unlink_catalog_collection
+- get_catalog_collection_items
+- get_catalog_collection_item
 - get_sub_catalogs
 - create_sub_catalog
 - unlink_sub_catalog
@@ -189,6 +242,8 @@ required async methods, including:
 
 ## Endpoints added by this extension
 
+### CatalogsExtension (read-only discovery)
+
 - GET /catalogs
 - GET /catalogs/{catalog_id}
 - GET /catalogs/{catalog_id}/collections
@@ -200,7 +255,10 @@ required async methods, including:
 - GET /catalogs/{catalog_id}/conformance
 - GET /catalogs/{catalog_id}/queryables
 
-When enable_transactions=True:
+### CatalogsTransactionExtension (write operations)
+
+When CatalogsTransactionExtension is enabled, the following additional endpoints
+are available for catalog and collection management:
 
 - POST /catalogs
 - PUT /catalogs/{catalog_id}

--- a/README.md
+++ b/README.md
@@ -167,8 +167,6 @@ from stac_fastapi.types.config import ApiSettings
 from stac_fastapi_catalogs_extension import (
     CatalogsExtension,
     CatalogsTransactionExtension,
-    CATALOGS_CORE_CONFORMANCE,
-    CATALOGS_TRANSACTION_CONFORMANCE,
 )
 from my_project.catalogs_client import CatalogsClient
 from my_project.core_client import CoreClient
@@ -185,8 +183,6 @@ api = StacApi(
     extensions=[
         CatalogsExtension(
             client=catalogs_client,
-            conformance_classes=list(CATALOGS_CORE_CONFORMANCE)
-            + list(CATALOGS_TRANSACTION_CONFORMANCE),
             settings=settings.model_dump(),
         ),
         CatalogsTransactionExtension(
@@ -198,6 +194,9 @@ api = StacApi(
 
 app = api.app
 ```
+
+The transaction conformance class is automatically registered when
+`CatalogsTransactionExtension` is included.
 
 ## Backend client requirements
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "stac-fastapi-catalogs-extension"
-version = "0.1.3"
+version = "0.2.0"
 description = "STAC FastAPI extension for multi-tenant catalogs"
 readme = "README.md"
 requires-python = ">=3.11"
@@ -18,7 +18,7 @@ dependencies = [
   "stac-fastapi.api",
   "stac-fastapi.types",
   "stac-pydantic",
-  "httpx",
+  "httpx<0.28",
   "typing-extensions>=4.0.0",
 ]
 
@@ -31,7 +31,7 @@ Issues = "https://github.com/StacLabs/stac-fastapi-catalogs-extension/issues"
 dev = [
   "black>=22.10.0",
   "flake8>=6.0.0",
-  "httpx",
+  "httpx<0.28",
   "isort>=5.12.0",
   "mypy>=0.991",
   "pre-commit>=3.0.0",

--- a/stac_fastapi_catalogs_extension/__init__.py
+++ b/stac_fastapi_catalogs_extension/__init__.py
@@ -1,6 +1,11 @@
 """Catalogs extension module."""
 
-from .catalogs import CATALOGS_CONFORMANCE_CLASSES, CatalogsExtension
+from .catalogs import (
+    CATALOGS_CORE_CONFORMANCE,
+    CATALOGS_TRANSACTION_CONFORMANCE,
+    CatalogsExtension,
+    CatalogsTransactionExtension,
+)
 from .client import AsyncBaseCatalogsClient, BaseCatalogsClient
 from .types import (
     CatalogChildrenRequest,
@@ -22,12 +27,14 @@ from .types import (
 
 __all__ = [
     "CatalogsExtension",
+    "CatalogsTransactionExtension",
     "AsyncBaseCatalogsClient",
     "BaseCatalogsClient",
     "Catalogs",
     "Children",
     "ObjectUri",
-    "CATALOGS_CONFORMANCE_CLASSES",
+    "CATALOGS_CORE_CONFORMANCE",
+    "CATALOGS_TRANSACTION_CONFORMANCE",
     "CatalogsUri",
     "CatalogsGetRequest",
     "CatalogCollectionUri",

--- a/stac_fastapi_catalogs_extension/catalogs.py
+++ b/stac_fastapi_catalogs_extension/catalogs.py
@@ -1,4 +1,4 @@
-"""Catalogs extension."""
+"""Multi-Tenant Catalogs Extensions."""
 
 from typing import Type
 
@@ -20,6 +20,7 @@ from .types import (
     CatalogChildrenRequest,
     CatalogCollectionItemsRequest,
     CatalogCollectionItemUri,
+    CatalogCollectionsRequest,
     CatalogCollectionUri,
     Catalogs,
     CatalogsGetRequest,
@@ -33,57 +34,50 @@ from .types import (
     UpdateCatalogRequest,
 )
 
-CATALOGS_CONFORMANCE_CLASSES = [
+# Conformance Classes
+CATALOGS_CORE_CONFORMANCE = [
     "https://api.stacspec.org/v1.0.0/core",
     "https://api.stacspec.org/v1.0.0-beta.4/multi-tenant-catalogs",
     "https://api.stacspec.org/v1.0.0-rc.2/children",
     "https://api.stacspec.org/v1.0.0-rc.2/children#type-filter",
 ]
 
-CATALOGS_TRANSACTION_CONFORMANCE_CLASS = (
+CATALOGS_TRANSACTION_CONFORMANCE = [
     "https://api.stacspec.org/v1.0.0-beta.4/multi-tenant-catalogs/transaction"
-)
+]
 
 
 @attr.s
 class CatalogsExtension(ApiExtension):
-    """Catalogs Extension (v1.0.0-beta.4).
+    """Catalogs Extension (Core / Read-Only).
 
-    The Catalogs extension adds a /catalogs endpoint that returns a list of all catalogs
-    in the database, similar to how /collections returns a list of collections.
+    The Catalogs extension provides discovery endpoints for a Multi-Tenant STAC
+    architecture. It introduces a `/catalogs` registry to support recursive
+    catalog hierarchies and poly-hierarchy (where collections or catalogs can
+    have multiple parents).
 
-    This extension enables Multi-Tenant architecture with recursive catalog hierarchies
-    and poly-hierarchy support (collections/catalogs can have multiple parents).
+    This class strictly implements the read-only discovery operations. For
+    creating, updating, or managing the hierarchy, see `CatalogsTransactionExtension`.
 
-    Link Strategy (v1.0.0-beta.4):
-    - Single parent link for contextual navigation
-    - rel="related" for additional parents (poly-hierarchy)
-    - rel="canonical" for global endpoints
-    - rel="duplicate" for alternative scoped paths
-
-    See client.py module docstring for detailed link strategy documentation.
+    For normative rules regarding Link Strategy, Contextual Navigation, and
+    HATEOAS link generation (e.g., `rel="parent"`, `rel="canonical"`), please
+    refer to the Multi-Tenant Catalogs specification.
 
     Attributes:
         client: A client implementing the catalogs extension pattern.
         settings: Extension settings.
-        enable_transactions: Enable catalog transaction endpoints (POST, PUT, DELETE).
         conformance_classes: List of conformance classes for this extension.
         router: FastAPI router for the extension endpoints.
         response_class: Response class for the extension.
     """
 
     client: AsyncBaseCatalogsClient = attr.ib(kw_only=True)
-    enable_transactions: bool = attr.ib(default=False, kw_only=True)
     settings: dict = attr.ib(default=attr.Factory(dict), kw_only=True)
-    conformance_classes: list[str] = attr.ib(factory=list, kw_only=True)
+    conformance_classes: list[str] = attr.ib(
+        default=attr.Factory(lambda: CATALOGS_CORE_CONFORMANCE.copy()), kw_only=True
+    )
     router: APIRouter = attr.ib(factory=APIRouter, kw_only=True)
     response_class: Type[Response] = attr.ib(default=JSONResponse, kw_only=True)
-
-    def __attrs_post_init__(self):
-        """Initialize conformance classes based on settings."""
-        self.conformance_classes = CATALOGS_CONFORMANCE_CLASSES.copy()
-        if self.enable_transactions:
-            self.conformance_classes.append(CATALOGS_TRANSACTION_CONFORMANCE_CLASS)
 
     def register(self, app: FastAPI) -> None:
         """Register the extension with a FastAPI application.
@@ -92,13 +86,7 @@ class CatalogsExtension(ApiExtension):
             app: target FastAPI application.
         """
         self.router.prefix = app.state.router_prefix
-        self.register_read_endpoints()
-        if self.enable_transactions:
-            self.register_transaction_endpoints()
-        app.include_router(self.router, tags=["Catalogs"])
 
-    def register_read_endpoints(self) -> None:
-        """Register all GET endpoints using the async factory."""
         # GET /catalogs
         self.router.add_api_route(
             name="Get All Catalogs",
@@ -137,7 +125,7 @@ class CatalogsExtension(ApiExtension):
             path="/catalogs/{catalog_id}/collections",
             methods=["GET"],
             endpoint=create_async_endpoint(
-                self.client.get_catalog_collections, CatalogsUri
+                self.client.get_catalog_collections, CatalogCollectionsRequest
             ),
             response_model=Collections
             if self.settings.get("enable_response_models", True)
@@ -261,8 +249,8 @@ class CatalogsExtension(ApiExtension):
             response_class=self.response_class,
             summary="Get Catalog Queryables",
             description=(
-                "Get queryable fields available for filtering in this "
-                "sub-catalog (Filter Extension)."
+                "Get queryable fields available for filtering "
+                "in this sub-catalog (Filter Extension)."
             ),
             tags=["Catalogs"],
             responses={
@@ -270,8 +258,67 @@ class CatalogsExtension(ApiExtension):
             },
         )
 
-    def register_transaction_endpoints(self) -> None:
-        """Register POST/PUT/DELETE endpoints."""
+        app.include_router(self.router, tags=["Catalogs"])
+
+    async def _get_catalog_conformance(
+        self, catalog_id: str, request=None, **kwargs
+    ) -> dict | Response:
+        """Merge client response with extension conformance classes.
+
+        Args:
+            catalog_id: ID of the catalog to fetch conformance for.
+            request: The incoming FastAPI request.
+
+        Returns:
+            Dictionary containing merged conformance classes.
+        """
+        result = await self.client.get_catalog_conformance(
+            catalog_id=catalog_id, request=request
+        )
+        if isinstance(result, dict):
+            conforms = result.get("conformsTo", [])
+            conforms.extend(self.conformance_classes)
+            result["conformsTo"] = list(set(conforms))
+        return result
+
+
+@attr.s
+class CatalogsTransactionExtension(ApiExtension):
+    """Catalogs Transaction Extension (Management / Write).
+
+    The Catalogs Transaction extension provides the `POST`, `PUT`, and `DELETE`
+    endpoints required to manage a Multi-Tenant STAC catalog registry and its
+    hierarchical relationships.
+
+    This extension follows a "Safety-First" policy: deletions via these endpoints
+    typically unlink resources (preserving data) rather than destroying them.
+
+    For normative rules regarding Adoption logic, Cycle Prevention, and structural
+    validation, please refer to the Multi-Tenant Catalogs specification.
+
+    Attributes:
+        client: An `AsyncBaseCatalogsClient` instance implementing the
+        transactional endpoints.
+        settings: Application settings dictionary.
+        conformance_classes: List of transactional conformance classes for this extension.
+        router: FastAPI router for the extension endpoints.
+        response_class: Response class for the extension (defaults to JSONResponse).
+    """
+
+    client: AsyncBaseCatalogsClient = attr.ib(kw_only=True)
+    settings: dict = attr.ib(default=attr.Factory(dict), kw_only=True)
+    conformance_classes: list[str] = attr.ib(default=attr.Factory(list), kw_only=True)
+    router: APIRouter = attr.ib(factory=APIRouter, kw_only=True)
+    response_class: Type[Response] = attr.ib(default=JSONResponse, kw_only=True)
+
+    def register(self, app: FastAPI) -> None:
+        """Register the transactional extension with a FastAPI application.
+
+        Args:
+            app: target FastAPI application.
+        """
+        self.router.prefix = app.state.router_prefix
+
         # POST /catalogs
         self.router.add_api_route(
             name="Create Catalog",
@@ -316,7 +363,7 @@ class CatalogsExtension(ApiExtension):
             endpoint=create_async_endpoint(self.client.delete_catalog, CatalogsUri),
             response_class=self.response_class,
             summary="Delete Catalog",
-            description="Delete a catalog.",
+            description="Delete a catalog (Unlinks children and preserves data).",
             tags=["Catalogs"],
         )
 
@@ -334,7 +381,9 @@ class CatalogsExtension(ApiExtension):
             else None,
             response_class=self.response_class,
             summary="Create Catalog Collection",
-            description="Create a new collection and link it to a specific catalog.",
+            description=(
+                "Create a new collection or link an existing one to this catalog."
+            ),
             tags=["Catalogs"],
         )
 
@@ -350,8 +399,7 @@ class CatalogsExtension(ApiExtension):
             response_class=self.response_class,
             summary="Unlink Collection from Catalog",
             description=(
-                "Removes the link between the catalog and collection. "
-                "The Collection data is NOT deleted."
+                "Removes the link between catalog and collection. Data is NOT deleted."
             ),
             tags=["Catalogs"],
         )
@@ -371,8 +419,7 @@ class CatalogsExtension(ApiExtension):
             response_class=self.response_class,
             summary="Create Catalog Sub-Catalog",
             description=(
-                "Create a new catalog or link an existing catalog as a "
-                "sub-catalog of a specific catalog."
+                "Create a new sub-catalog or link an existing catalog to this parent."
             ),
             tags=["Catalogs"],
         )
@@ -389,23 +436,9 @@ class CatalogsExtension(ApiExtension):
             response_class=self.response_class,
             summary="Unlink Sub-Catalog",
             description=(
-                "Unlink a sub-catalog from its parent. "
-                "Does not delete the sub-catalog."
+                "Unlink a sub-catalog from its parent. Does not delete the catalog."
             ),
             tags=["Catalogs"],
         )
 
-    async def _get_catalog_conformance(
-        self, catalog_id: str, request=None, **kwargs
-    ) -> dict | Response:
-        """Merge client response with extension conformance classes."""
-        result = await self.client.get_catalog_conformance(
-            catalog_id=catalog_id, request=request
-        )
-        # Merge extension conformance classes with client response
-        if isinstance(result, dict):
-            if "conformsTo" in result:
-                result["conformsTo"].extend(self.conformance_classes)
-            else:
-                result["conformsTo"] = self.conformance_classes
-        return result
+        app.include_router(self.router, tags=["Catalogs"])

--- a/stac_fastapi_catalogs_extension/catalogs.py
+++ b/stac_fastapi_catalogs_extension/catalogs.py
@@ -87,6 +87,11 @@ class CatalogsExtension(ApiExtension):
         """
         self.router.prefix = app.state.router_prefix
 
+        # Share conformance classes via app.state registry
+        if not hasattr(app.state, "catalogs_conformance_classes"):
+            app.state.catalogs_conformance_classes = set()
+        app.state.catalogs_conformance_classes.update(self.conformance_classes)
+
         # GET /catalogs
         self.router.add_api_route(
             name="Get All Catalogs",
@@ -277,7 +282,11 @@ class CatalogsExtension(ApiExtension):
         )
         if isinstance(result, dict):
             conforms = result.get("conformsTo", [])
-            conforms.extend(self.conformance_classes)
+            # Dynamically fetch ALL catalog conformance classes from app.state
+            if request and hasattr(request.app.state, "catalogs_conformance_classes"):
+                conforms.extend(request.app.state.catalogs_conformance_classes)
+            else:
+                conforms.extend(self.conformance_classes)
             result["conformsTo"] = list(set(conforms))
         return result
 
@@ -307,7 +316,10 @@ class CatalogsTransactionExtension(ApiExtension):
 
     client: AsyncBaseCatalogsClient = attr.ib(kw_only=True)
     settings: dict = attr.ib(default=attr.Factory(dict), kw_only=True)
-    conformance_classes: list[str] = attr.ib(default=attr.Factory(list), kw_only=True)
+    conformance_classes: list[str] = attr.ib(
+        default=attr.Factory(lambda: CATALOGS_TRANSACTION_CONFORMANCE.copy()),
+        kw_only=True,
+    )
     router: APIRouter = attr.ib(factory=APIRouter, kw_only=True)
     response_class: Type[Response] = attr.ib(default=JSONResponse, kw_only=True)
 
@@ -318,6 +330,11 @@ class CatalogsTransactionExtension(ApiExtension):
             app: target FastAPI application.
         """
         self.router.prefix = app.state.router_prefix
+
+        # Inject transaction conformance into the shared catalog state
+        if not hasattr(app.state, "catalogs_conformance_classes"):
+            app.state.catalogs_conformance_classes = set()
+        app.state.catalogs_conformance_classes.update(self.conformance_classes)
 
         # POST /catalogs
         self.router.add_api_route(

--- a/stac_fastapi_catalogs_extension/client.py
+++ b/stac_fastapi_catalogs_extension/client.py
@@ -1,45 +1,11 @@
 """Catalogs extension clients.
 
-Link Strategy for v1.0.0-beta.4
-================================
+This module defines the abstract base classes for implementing the Multi-Tenant
+Catalogs extension.
 
-The v1.0.0-beta.4 specification introduces a refined link strategy to support
-poly-hierarchy (multi-parenting) while maintaining clear contextual navigation
-for UI clients like STAC Browser.
-
-Key Principles:
---------------
-1. **Single Parent Link**: Every resource MUST have exactly ONE rel="parent" link
-   that represents the contextual navigation path the user took to reach it.
-
-2. **Poly-Hierarchy via Related Links**: When a resource has multiple parents,
-   the API MAY include rel="related" links to expose alternative parents.
-   Implementations should filter these based on user permissions (RBAC).
-
-3. **Canonical Links**: Scoped endpoints SHOULD include rel="canonical" links
-   pointing to the global endpoint for the same resource.
-
-4. **Duplicate Links**: Scoped endpoints MAY include rel="duplicate" links
-   pointing to other scoped paths where the same resource exists.
-
-Scoped vs. Global Routes:
-------------------------
-- **Scoped Routes** (/catalogs/{id}/collections/{col_id}):
-  - rel="parent" points to the specific catalog in the path
-  - Maintains breadcrumb trail for UI navigation
-  - rel="canonical" points to global endpoint
-  - rel="related" exposes other parents
-
-- **Global Routes** (/collections/{col_id}):
-  - rel="parent" points to the Global Root (/)
-  - rel="related" MAY include all catalogs that claim this collection
-
-Dynamic Link Generation:
------------------------
-Implementations SHOULD NOT persist static rel="parent" or rel="child" links
-in the database. Instead, links should be dynamically generated at runtime
-based on the requested endpoint to properly support poly-hierarchy and
-maintain contextual navigation.
+For normative rules regarding Poly-Hierarchy, Dynamic Link Generation (HATEOAS),
+Contextual Navigation, and Transactional Safety, please refer to the official
+Multi-Tenant Catalogs specification.
 """
 
 import abc
@@ -103,17 +69,9 @@ class AsyncBaseCatalogsClient(abc.ABC):
     ) -> Catalog | Response:
         """Get a specific catalog by ID.
 
-        Link Strategy (v1.0.0-beta.4):
-        - rel="parent": MUST point to exactly ONE immediate parent catalog.
-          If top-level, points to the Global Root (/).
-        - rel="related": If the catalog has multiple parents (poly-hierarchy),
-          MAY include links to other parent catalogs (filtered by user permissions).
-        - rel="child": MUST point to all immediate sub-catalogs and collections.
-        - rel="root": MUST point to the Global Root (/).
-
-        Implementations SHOULD dynamically generate these links at runtime based
-        on the requested endpoint to support poly-hierarchy. Static linking is
-        highly discouraged.
+        For normative rules regarding Link Strategy and HATEOAS relations
+        (such as `rel="parent"`, `rel="related"`, and `rel="child"`), see
+        the Multi-Tenant Catalogs specification.
 
         Args:
             catalog_id: The ID of the catalog to retrieve.
@@ -153,6 +111,9 @@ class AsyncBaseCatalogsClient(abc.ABC):
     ) -> None:
         """Delete a catalog.
 
+        For normative rules regarding the Safety-First architecture and
+        Adoption logic during deletion, see the Multi-Tenant Catalogs specification.
+
         Args:
             catalog_id: The ID of the catalog to delete.
             request: Optional FastAPI request object.
@@ -169,13 +130,6 @@ class AsyncBaseCatalogsClient(abc.ABC):
         **kwargs,
     ) -> Collections | Response:
         """Get collections linked from a specific catalog.
-
-        Link Strategy (v1.0.0-beta.4 - Scoped Route):
-        To preserve contextual breadcrumb navigation in UI clients (e.g., STAC Browser):
-        - rel="parent": MUST point exclusively to the specific catalog_id.
-        - rel="related": MAY include links to other parent catalogs (poly-hierarchy).
-        - rel="canonical": SHOULD point to the global /collections/{id} endpoint.
-        - rel="duplicate": MAY point to other scoped paths for this collection.
 
         Args:
             catalog_id: The ID of the catalog.
@@ -220,23 +174,13 @@ class AsyncBaseCatalogsClient(abc.ABC):
     ) -> Catalog | Response:
         """Create a new catalog or link an existing catalog as a sub-catalog.
 
-        Supports two modes:
-        - Mode A (Creation): Full Catalog JSON body with id that doesn't exist
-          → creates new catalog
-        - Mode B (Linking): Minimal body with just id of existing catalog
-          → links as sub-catalog
-
-        Logic:
-        1. Verifies the parent catalog exists.
-        2. If the sub-catalog already exists: Appends the parent ID to its
-           parent_ids (enabling poly-hierarchy - a catalog can have multiple
-           parents).
-        3. If the sub-catalog is new: Creates it with parent_ids initialized
-           to [catalog_id].
+        The behavior of this endpoint depends on the provided payload.
+        For normative rules regarding Creation (Full Body) vs. Linking (Reference Only),
+        see the Multi-Tenant Catalogs specification.
 
         Args:
             catalog_id: The ID of the parent catalog.
-            catalog: The catalog to create or link (full Catalog or ObjectUri with id).
+            catalog: The catalog to create (Full Catalog) or link (ObjectUri with id).
             request: Optional FastAPI request object.
 
         Returns:
@@ -252,17 +196,15 @@ class AsyncBaseCatalogsClient(abc.ABC):
         request: Request | None = None,
         **kwargs,
     ) -> Collection | Response:
-        """Create a new collection or link an existing collection to catalog.
+        """Create a new collection or link an existing one to this catalog.
 
-        Supports two modes:
-        - Mode A (Creation): Full Collection JSON body with id that doesn't
-          exist → creates new collection
-        - Mode B (Linking): Minimal body with just id of existing collection
-          → links to catalog
+        The behavior of this endpoint depends on the provided payload.
+        For normative rules regarding Creation (Full Body) vs. Linking (Reference Only),
+        see the Multi-Tenant Catalogs specification.
 
         Args:
             catalog_id: The ID of the catalog to link the collection to.
-            collection: Create or link (full Collection or ObjectUri with id).
+            collection: Create a (Full Collection) or link (ObjectUri with id).
             request: Optional FastAPI request object.
 
         Returns:
@@ -280,14 +222,9 @@ class AsyncBaseCatalogsClient(abc.ABC):
     ) -> Collection | Response:
         """Get a specific collection from a catalog (Scoped Route).
 
-        Link Strategy (v1.0.0-beta.4 - Scoped Route):
-        This endpoint provides contextual navigation within a specific catalog:
-        - rel="self": MUST point to /catalogs/{catalog_id}/collections/{collection_id}.
-        - rel="parent": MUST point exclusively to /catalogs/{catalog_id}.
-        - rel="related": MAY include links to other parent catalogs (poly-hierarchy).
-        - rel="canonical": SHOULD point to /collections/{collection_id} (global endpoint).
-        - rel="duplicate": MAY point to other scoped paths where this collection exists.
-        - rel="root": MUST point to the Global Root (/).
+        For normative rules regarding scoped HATEOAS relations (e.g., `rel="canonical"`,
+        `rel="duplicate"`, and strict single `rel="parent"` links), see the
+        Multi-Tenant Catalogs specification.
 
         Args:
             catalog_id: The ID of the catalog.
@@ -310,7 +247,8 @@ class AsyncBaseCatalogsClient(abc.ABC):
         """Unlink a collection from a catalog.
 
         Removes the link between the catalog and collection.
-        The Collection data is NOT deleted.
+        For normative rules regarding the Safety-First architecture and
+        Adoption logic during unlinking, see the Multi-Tenant Catalogs specification.
 
         Args:
             catalog_id: The ID of the catalog.
@@ -336,14 +274,6 @@ class AsyncBaseCatalogsClient(abc.ABC):
         Multiple filters are combined using AND logic. If both bbox and datetime
         are provided, only items matching both criteria are returned.
 
-        Link Strategy (v1.0.0-beta.4 - Scoped Route):
-        Links in the ItemCollection should maintain the scoped context:
-        - rel="collection": MUST point to
-          /catalogs/{catalog_id}/collections/{collection_id}.
-        - rel="parent": MUST point to
-          /catalogs/{catalog_id}/collections/{collection_id}.
-        - rel="root": MUST point to the Global Root (/).
-
         Args:
             catalog_id: The ID of the catalog.
             collection_id: The ID of the collection.
@@ -368,16 +298,6 @@ class AsyncBaseCatalogsClient(abc.ABC):
         **kwargs,
     ) -> Item | Response:
         """Get a specific item from a collection in a catalog.
-
-        Link Strategy (v1.0.0-beta.4 - Scoped Route):
-        Links in the Item should maintain the scoped context:
-        - rel="self": MUST point to
-          /catalogs/{catalog_id}/collections/{collection_id}/items/{item_id}.
-        - rel="collection": MUST point to
-          /catalogs/{catalog_id}/collections/{collection_id}.
-        - rel="parent": MUST point to
-          /catalogs/{catalog_id}/collections/{collection_id}.
-        - rel="root": MUST point to the Global Root (/).
 
         Args:
             catalog_id: The ID of the catalog.
@@ -453,6 +373,9 @@ class AsyncBaseCatalogsClient(abc.ABC):
         **kwargs,
     ) -> None:
         """Unlink a sub-catalog from its parent.
+
+        For normative rules regarding the Safety-First architecture and
+        Adoption logic during unlinking, see the Multi-Tenant Catalogs specification.
 
         Args:
             catalog_id: The ID of the parent catalog.

--- a/stac_fastapi_catalogs_extension/types.py
+++ b/stac_fastapi_catalogs_extension/types.py
@@ -61,6 +61,19 @@ class CatalogCollectionItemUri(CatalogCollectionUri):
 
 
 @attr.s
+class CatalogCollectionsRequest(CatalogsUri):
+    """Parameters for /catalogs/{catalog_id}/collections endpoint."""
+
+    limit: Annotated[
+        int | None,
+        Query(ge=1, le=1000, description="Maximum number of collections to return"),
+    ] = attr.ib(default=10)
+    token: Annotated[str | None, Query(description="Pagination token")] = attr.ib(
+        default=None
+    )
+
+
+@attr.s
 class CatalogCollectionItemsRequest(CatalogCollectionUri):
     """Parameters for /catalogs/{catalog_id}/collections/{collection_id}/items."""
 

--- a/tests/test_catalogs.py
+++ b/tests/test_catalogs.py
@@ -420,11 +420,6 @@ def client(
     core_client: DummyCoreClient, catalogs_client: DummyCatalogsClient
 ) -> TestClient:
     """Fixture for test client with transactions enabled."""
-    from stac_fastapi_catalogs_extension import (
-        CATALOGS_CORE_CONFORMANCE,
-        CATALOGS_TRANSACTION_CONFORMANCE,
-    )
-
     settings = ApiSettings()
     api = StacApi(
         settings=settings,
@@ -433,8 +428,6 @@ def client(
             CatalogsExtension(
                 client=catalogs_client,
                 settings=settings.model_dump(),
-                conformance_classes=list(CATALOGS_CORE_CONFORMANCE)
-                + list(CATALOGS_TRANSACTION_CONFORMANCE),
             ),
             CatalogsTransactionExtension(
                 client=catalogs_client,
@@ -442,7 +435,8 @@ def client(
             ),
         ],
     )
-    return TestClient(api.app)
+    with TestClient(api.app) as test_client:
+        yield test_client
 
 
 @pytest.fixture
@@ -450,11 +444,6 @@ def client_with_transactions(
     core_client: DummyCoreClient, catalogs_client: DummyCatalogsClient
 ) -> TestClient:
     """Fixture for test client with transactions enabled."""
-    from stac_fastapi_catalogs_extension import (
-        CATALOGS_CORE_CONFORMANCE,
-        CATALOGS_TRANSACTION_CONFORMANCE,
-    )
-
     settings = ApiSettings()
     api = StacApi(
         settings=settings,
@@ -463,8 +452,6 @@ def client_with_transactions(
             CatalogsExtension(
                 client=catalogs_client,
                 settings=settings.model_dump(),
-                conformance_classes=list(CATALOGS_CORE_CONFORMANCE)
-                + list(CATALOGS_TRANSACTION_CONFORMANCE),
             ),
             CatalogsTransactionExtension(
                 client=catalogs_client,
@@ -472,7 +459,8 @@ def client_with_transactions(
             ),
         ],
     )
-    return TestClient(api.app)
+    with TestClient(api.app) as test_client:
+        yield test_client
 
 
 @pytest.fixture
@@ -491,7 +479,8 @@ def client_readonly(
             ),
         ],
     )
-    return TestClient(api.app)
+    with TestClient(api.app) as test_client:
+        yield test_client
 
 
 def test_get_catalogs(client: TestClient) -> None:

--- a/tests/test_catalogs.py
+++ b/tests/test_catalogs.py
@@ -1,6 +1,5 @@
 """Tests for the Catalogs extension."""
 
-from collections.abc import Iterator
 from datetime import datetime
 
 import pytest
@@ -16,7 +15,10 @@ from stac_pydantic.item_collection import ItemCollection
 from starlette.responses import Response
 from starlette.testclient import TestClient
 
-from stac_fastapi_catalogs_extension import CatalogsExtension
+from stac_fastapi_catalogs_extension import (
+    CatalogsExtension,
+    CatalogsTransactionExtension,
+)
 from stac_fastapi_catalogs_extension.client import AsyncBaseCatalogsClient
 from stac_fastapi_catalogs_extension.types import Catalogs, Children, ObjectUri
 
@@ -416,8 +418,13 @@ def catalogs_client() -> DummyCatalogsClient:
 @pytest.fixture
 def client(
     core_client: DummyCoreClient, catalogs_client: DummyCatalogsClient
-) -> Iterator[TestClient]:
+) -> TestClient:
     """Fixture for test client with transactions enabled."""
+    from stac_fastapi_catalogs_extension import (
+        CATALOGS_CORE_CONFORMANCE,
+        CATALOGS_TRANSACTION_CONFORMANCE,
+    )
+
     settings = ApiSettings()
     api = StacApi(
         settings=settings,
@@ -425,19 +432,53 @@ def client(
         extensions=[
             CatalogsExtension(
                 client=catalogs_client,
-                enable_transactions=True,
+                settings=settings.model_dump(),
+                conformance_classes=list(CATALOGS_CORE_CONFORMANCE)
+                + list(CATALOGS_TRANSACTION_CONFORMANCE),
+            ),
+            CatalogsTransactionExtension(
+                client=catalogs_client,
                 settings=settings.model_dump(),
             ),
         ],
     )
-    with TestClient(api.app) as test_client:
-        yield test_client
+    return TestClient(api.app)
+
+
+@pytest.fixture
+def client_with_transactions(
+    core_client: DummyCoreClient, catalogs_client: DummyCatalogsClient
+) -> TestClient:
+    """Fixture for test client with transactions enabled."""
+    from stac_fastapi_catalogs_extension import (
+        CATALOGS_CORE_CONFORMANCE,
+        CATALOGS_TRANSACTION_CONFORMANCE,
+    )
+
+    settings = ApiSettings()
+    api = StacApi(
+        settings=settings,
+        client=core_client,
+        extensions=[
+            CatalogsExtension(
+                client=catalogs_client,
+                settings=settings.model_dump(),
+                conformance_classes=list(CATALOGS_CORE_CONFORMANCE)
+                + list(CATALOGS_TRANSACTION_CONFORMANCE),
+            ),
+            CatalogsTransactionExtension(
+                client=catalogs_client,
+                settings=settings.model_dump(),
+            ),
+        ],
+    )
+    return TestClient(api.app)
 
 
 @pytest.fixture
 def client_readonly(
     core_client: DummyCoreClient, catalogs_client: DummyCatalogsClient
-) -> Iterator[TestClient]:
+) -> TestClient:
     """Fixture for test client with transactions disabled (read-only)."""
     settings = ApiSettings()
     api = StacApi(
@@ -446,13 +487,11 @@ def client_readonly(
         extensions=[
             CatalogsExtension(
                 client=catalogs_client,
-                enable_transactions=False,
                 settings=settings.model_dump(),
             ),
         ],
     )
-    with TestClient(api.app) as test_client:
-        yield test_client
+    return TestClient(api.app)
 
 
 def test_get_catalogs(client: TestClient) -> None:


### PR DESCRIPTION
### Added

- Split Catalogs extension into two classes:
  - `CatalogsExtension`: Read-only discovery endpoints
  - `CatalogsTransactionExtension`: Write operations (POST, PUT, DELETE)
- Dynamic conformance class registration via `app.state` for seamless extension composition

### Changed

- **BREAKING**: `CatalogsExtension` no longer accepts `enable_transactions` parameter. Use `CatalogsTransactionExtension` separately for write operations.
- Conformance classes are now explicitly passed during initialization, following standard STAC FastAPI extension patterns.

### Fixed

- Pinned `httpx<0.28` to prevent URL parsing breaking changes in httpx 0.28.0+