### PR TITLE
Add PUT scoped collections route for DAG safety

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,19 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 
-## [v0.2.0] - 2026-10-14
+## [v0.3.0] - 2026-05-20
+
+### Added
+
+- `update_catalog_collection` method and PUT /catalogs/{catalog_id}/collections/{collection_id} endpoint for updating collection metadata within a catalog context
+
+### Changed
+
+- Updated conformance class URIs from beta.4 to rc.1:
+  - https://api.stacspec.org/v1.0.0-rc.1/multi-tenant-catalogs
+  - https://api.stacspec.org/v1.0.0-rc.1/multi-tenant-catalogs/transaction
+
+## [v0.2.0] - 2026-05-02
 
 ### Added
 
@@ -83,7 +95,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 	with the Black profile.
 
 
-[Unreleased]: https://github.com/StacLabs/stac-fastapi-catalogs-extension/compare/v0.2.0...main
+[Unreleased]: https://github.com/StacLabs/stac-fastapi-catalogs-extension/compare/v0.3.0...main
+[v0.3.0]: https://github.com/StacLabs/stac-fastapi-catalogs-extension/compare/v0.2.0...v0.3.0
 [v0.2.0]: https://github.com/StacLabs/stac-fastapi-catalogs-extension/compare/v0.1.2...v0.2.0
 [v0.1.2]: https://github.com/StacLabs/stac-fastapi-catalogs-extension/compare/v0.1.1...v0.1.2
 [v0.1.1]: https://github.com/StacLabs/stac-fastapi-catalogs-extension/compare/v0.1.0...v0.1.1

--- a/README.md
+++ b/README.md
@@ -71,11 +71,11 @@ according to your enabled capabilities:
 
 - Required:
 	- https://api.stacspec.org/v1.0.0/core
-	- https://api.stacspec.org/v1.0.0-beta.4/multi-tenant-catalogs
+	- https://api.stacspec.org/v1.0.0-rc.1/multi-tenant-catalogs
 - Recommended:
 	- https://api.stacspec.org/v1.0.0-rc.2/children
 - Optional (only if transaction endpoints are enabled):
-	- https://api.stacspec.org/v1.0.0-beta.4/multi-tenant-catalogs/transaction
+	- https://api.stacspec.org/v1.0.0-rc.1/multi-tenant-catalogs/transaction
 
 Operational guidance:
 
@@ -83,6 +83,12 @@ Operational guidance:
 	should not advertise the transaction conformance class.
 - If transactions are enabled, expose and document the management endpoints and
 	include the transaction conformance class in conformance responses.
+- **Important**: To preserve the poly-hierarchy DAG structure, updates to
+	collections SHOULD be performed through scoped routes
+	(`/catalogs/{catalogId}/collections/{collectionId}`) rather than the core STAC
+	route (`/collections/{collectionId}`). The core route is flat and does not
+	maintain parent-child relationships, so updates through that route may not
+	properly preserve the hierarchical context.
 
 ## Supported projects
 
@@ -211,6 +217,7 @@ required async methods, including:
 - get_catalog_collections
 - create_catalog_collection
 - get_catalog_collection
+- update_catalog_collection
 - unlink_catalog_collection
 - get_catalog_collection_items
 - get_catalog_collection_item
@@ -263,6 +270,7 @@ are available for catalog and collection management:
 - PUT /catalogs/{catalog_id}
 - DELETE /catalogs/{catalog_id}
 - POST /catalogs/{catalog_id}/collections
+- PUT /catalogs/{catalog_id}/collections/{collection_id}
 - DELETE /catalogs/{catalog_id}/collections/{collection_id}
 - POST /catalogs/{catalog_id}/catalogs
 - DELETE /catalogs/{catalog_id}/catalogs/{sub_catalog_id}

--- a/stac_fastapi_catalogs_extension/__init__.py
+++ b/stac_fastapi_catalogs_extension/__init__.py
@@ -1,4 +1,4 @@
-"""Catalogs extension module."""
+"""stac-fastapi-catalogs-extension: Multi-tenant catalog hierarchies for STAC FastAPI."""
 
 from .catalogs import (
     CATALOGS_CORE_CONFORMANCE,

--- a/stac_fastapi_catalogs_extension/catalogs.py
+++ b/stac_fastapi_catalogs_extension/catalogs.py
@@ -31,19 +31,20 @@ from .types import (
     CreateSubCatalogRequest,
     SubCatalogsRequest,
     UnlinkSubCatalogRequest,
+    UpdateCatalogCollectionRequest,
     UpdateCatalogRequest,
 )
 
 # Conformance Classes
 CATALOGS_CORE_CONFORMANCE = [
     "https://api.stacspec.org/v1.0.0/core",
-    "https://api.stacspec.org/v1.0.0-beta.4/multi-tenant-catalogs",
+    "https://api.stacspec.org/v1.0.0-rc.1/multi-tenant-catalogs",
     "https://api.stacspec.org/v1.0.0-rc.2/children",
     "https://api.stacspec.org/v1.0.0-rc.2/children#type-filter",
 ]
 
 CATALOGS_TRANSACTION_CONFORMANCE = [
-    "https://api.stacspec.org/v1.0.0-beta.4/multi-tenant-catalogs/transaction"
+    "https://api.stacspec.org/v1.0.0-rc.1/multi-tenant-catalogs/transaction"
 ]
 
 
@@ -400,6 +401,27 @@ class CatalogsTransactionExtension(ApiExtension):
             summary="Create Catalog Collection",
             description=(
                 "Create a new collection or link an existing one to this catalog."
+            ),
+            tags=["Catalogs"],
+        )
+
+        # PUT /catalogs/{catalog_id}/collections/{collection_id}
+        self.router.add_api_route(
+            name="Update Catalog Collection",
+            path="/catalogs/{catalog_id}/collections/{collection_id}",
+            methods=["PUT"],
+            status_code=HTTP_200_OK,
+            endpoint=create_async_endpoint(
+                self.client.update_catalog_collection, UpdateCatalogCollectionRequest
+            ),
+            response_model=Collection
+            if self.settings.get("enable_response_models", True)
+            else None,
+            response_class=self.response_class,
+            summary="Update Catalog Collection",
+            description=(
+                "Update collection metadata within a catalog context. "
+                "Preserves structural links to maintain poly-hierarchy."
             ),
             tags=["Catalogs"],
         )

--- a/stac_fastapi_catalogs_extension/client.py
+++ b/stac_fastapi_catalogs_extension/client.py
@@ -258,6 +258,35 @@ class AsyncBaseCatalogsClient(abc.ABC):
         ...
 
     @abc.abstractmethod
+    async def update_catalog_collection(
+        self,
+        catalog_id: str,
+        collection_id: str,
+        collection: Collection,
+        request: Request | None = None,
+        **kwargs,
+    ) -> Collection | Response:
+        """Update a collection within a catalog context.
+
+        Updates the metadata (Title, Description, etc.) of the collection
+        within the scoped catalog context. This operation preserves the
+        collection's structural links (parent_ids) to maintain the poly-hierarchy.
+
+        For normative rules regarding Safety-First architecture during updates,
+        see the Multi-Tenant Catalogs specification.
+
+        Args:
+            catalog_id: The ID of the catalog.
+            collection_id: The ID of the collection.
+            collection: The updated collection data.
+            request: Optional FastAPI request object.
+
+        Returns:
+            The updated collection.
+        """
+        ...
+
+    @abc.abstractmethod
     async def get_catalog_collection_items(
         self,
         catalog_id: str,

--- a/stac_fastapi_catalogs_extension/types.py
+++ b/stac_fastapi_catalogs_extension/types.py
@@ -151,6 +151,13 @@ class CreateCatalogCollectionRequest(CatalogsUri):
 
 
 @attr.s
+class UpdateCatalogCollectionRequest(CatalogCollectionUri):
+    """Update catalog collection with body."""
+
+    collection: Annotated[Collection, Body()] = attr.ib(default=None)
+
+
+@attr.s
 class CreateSubCatalogRequest(CatalogsUri):
     """Create sub-catalog with body."""
 

--- a/tests/test_catalogs.py
+++ b/tests/test_catalogs.py
@@ -259,6 +259,16 @@ class DummyCatalogsClient(AsyncBaseCatalogsClient):
     ) -> None:
         return None
 
+    async def update_catalog_collection(
+        self,
+        catalog_id: str,
+        collection_id: str,
+        collection: Collection,
+        request: Request | None = None,
+        **kwargs,
+    ) -> Collection | Response:
+        return collection
+
     async def get_catalog_collection_items(
         self,
         catalog_id: str,
@@ -533,6 +543,29 @@ def test_update_catalog(client: TestClient) -> None:
     assert response.status_code == 200, response.text
     data = response.json()
     assert data["id"] == "test-catalog-1"
+
+
+def test_update_catalog_collection(client: TestClient) -> None:
+    """Test PUT /catalogs/{catalog_id}/collections/{collection_id} endpoint."""
+    collection_data = {
+        "type": "Collection",
+        "id": "collection-1",
+        "description": "Updated collection description",
+        "stac_version": "1.0.0",
+        "license": "MIT",
+        "extent": {
+            "spatial": {"bbox": [[-180, -90, 180, 90]]},
+            "temporal": {"interval": [["2021-01-01T00:00:00Z", None]]},
+        },
+        "links": [],
+    }
+    response = client.put(
+        "/catalogs/test-catalog-1/collections/collection-1", json=collection_data
+    )
+    assert response.status_code == 200, response.text
+    data = response.json()
+    assert data["id"] == "collection-1"
+    assert data["description"] == "Updated collection description"
 
 
 def test_delete_catalog(client: TestClient) -> None:
@@ -870,6 +903,6 @@ def test_enabled_conformance_includes_transaction_class(client: TestClient) -> N
     data = response.json()
     assert "conformsTo" in data
     transaction_class = (
-        "https://api.stacspec.org/v1.0.0-beta.4/multi-tenant-catalogs/transaction"
+        "https://api.stacspec.org/v1.0.0-rc.1/multi-tenant-catalogs/transaction"
     )
     assert transaction_class in data["conformsTo"]


### PR DESCRIPTION
https://github.com/stac-utils/stac-fastapi-pgstac/pull/366

- `update_catalog_collection` method and PUT /catalogs/{catalog_id}/collections/{collection_id} endpoint for updating collection metadata within a catalog context
- Updated conformance class URIs from beta.4 to rc.1:
  - https://api.stacspec.org/v1.0.0-rc.1/multi-tenant-catalogs
  - https://api.stacspec.org/v1.0.0-rc.1/multi-tenant-catalogs/transaction
 - release v0.3.0