### PR TITLE
Hide alternate parents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 
+- `hide_alternate_parents` configuration flag to optionally disable advertising
+  alternative parents in poly-hierarchy via `rel="related"` links. Useful for
+  multi-tenant deployments to prevent information leakage about other tenants.
+
 ### Updated
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,10 +9,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 
-- `hide_alternate_parents` configuration flag to optionally disable advertising
-  alternative parents in poly-hierarchy via `rel="related"` links. Useful for
-  multi-tenant deployments to prevent information leakage about other tenants.
-
 ### Updated
 
 ### Changed
@@ -20,6 +16,14 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Removed
 
 ### Fixed
+
+## [v0.4.0] - 2026-06-08
+
+### Added
+
+- `hide_alternate_parents` configuration flag to optionally disable advertising
+  alternative parents in poly-hierarchy via `rel="related"` links. Useful for
+  multi-tenant deployments to prevent information leakage about other tenants. [#14](https://github.com/StacLabs/stac-fastapi-catalogs-extension/pull/14)
 
 ## [v0.3.0] - 2026-05-20
 
@@ -99,7 +103,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 	with the Black profile.
 
 
-[Unreleased]: https://github.com/StacLabs/stac-fastapi-catalogs-extension/compare/v0.3.0...main
+[Unreleased]: https://github.com/StacLabs/stac-fastapi-catalogs-extension/compare/v0.4.0...main
+[v0.4.0]: https://github.com/StacLabs/stac-fastapi-catalogs-extension/compare/v0.3.0...v0.4.0
 [v0.3.0]: https://github.com/StacLabs/stac-fastapi-catalogs-extension/compare/v0.2.0...v0.3.0
 [v0.2.0]: https://github.com/StacLabs/stac-fastapi-catalogs-extension/compare/v0.1.2...v0.2.0
 [v0.1.2]: https://github.com/StacLabs/stac-fastapi-catalogs-extension/compare/v0.1.1...v0.1.2

--- a/README.md
+++ b/README.md
@@ -90,6 +90,23 @@ Operational guidance:
 	maintain parent-child relationships, so updates through that route may not
 	properly preserve the hierarchical context.
 
+### Multi-Tenant Security
+
+For multi-tenant deployments where you want to prevent information leakage about
+other tenants, use the `hide_alternate_parents` flag:
+
+```python
+CatalogsExtension(
+    client=catalogs_client,
+    hide_alternate_parents=True,  # Disables rel="related" links to alternative parents
+)
+```
+
+When `hide_alternate_parents=True`, the API will only advertise the single
+contextual parent through `rel="parent"` and will not expose alternative parents
+via `rel="related"` links. This prevents clients from discovering the names and
+structure of other tenants in the system.
+
 ## Supported projects
 
 This extension is designed for STAC FastAPI deployment applications and is

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,6 @@ dependencies = [
   "stac-fastapi.api",
   "stac-fastapi.types",
   "stac-pydantic",
-  "httpx<0.28",
   "typing-extensions>=4.0.0",
 ]
 
@@ -31,7 +30,6 @@ Issues = "https://github.com/StacLabs/stac-fastapi-catalogs-extension/issues"
 dev = [
   "black>=22.10.0",
   "flake8>=6.0.0",
-  "httpx<0.28",
   "isort>=5.12.0",
   "mypy>=0.991",
   "pre-commit>=3.0.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,7 @@ dependencies = [
   "stac-fastapi.api",
   "stac-fastapi.types",
   "stac-pydantic",
+  "httpx<0.28",
   "typing-extensions>=4.0.0",
 ]
 
@@ -30,6 +31,7 @@ Issues = "https://github.com/StacLabs/stac-fastapi-catalogs-extension/issues"
 dev = [
   "black>=22.10.0",
   "flake8>=6.0.0",
+  "httpx<0.28",
   "isort>=5.12.0",
   "mypy>=0.991",
   "pre-commit>=3.0.0",

--- a/stac_fastapi_catalogs_extension/catalogs.py
+++ b/stac_fastapi_catalogs_extension/catalogs.py
@@ -70,6 +70,9 @@ class CatalogsExtension(ApiExtension):
         conformance_classes: List of conformance classes for this extension.
         router: FastAPI router for the extension endpoints.
         response_class: Response class for the extension.
+        hide_alternate_parents: If True, do not advertise rel="related" links to
+            alternative parents in poly-hierarchy. Useful for multi-tenant deployments
+            to prevent information leakage about other tenants.
     """
 
     client: AsyncBaseCatalogsClient = attr.ib(kw_only=True)
@@ -79,6 +82,7 @@ class CatalogsExtension(ApiExtension):
     )
     router: APIRouter = attr.ib(factory=APIRouter, kw_only=True)
     response_class: Type[Response] = attr.ib(default=JSONResponse, kw_only=True)
+    hide_alternate_parents: bool = attr.ib(default=False, kw_only=True)
 
     def register(self, app: FastAPI) -> None:
         """Register the extension with a FastAPI application.
@@ -92,6 +96,9 @@ class CatalogsExtension(ApiExtension):
         if not hasattr(app.state, "catalogs_conformance_classes"):
             app.state.catalogs_conformance_classes = set()
         app.state.catalogs_conformance_classes.update(self.conformance_classes)
+
+        # Store hide_alternate_parents flag for client access
+        app.state.catalogs_hide_alternate_parents = self.hide_alternate_parents
 
         # GET /catalogs
         self.router.add_api_route(

--- a/tests/test_catalogs.py
+++ b/tests/test_catalogs.py
@@ -906,3 +906,38 @@ def test_enabled_conformance_includes_transaction_class(client: TestClient) -> N
         "https://api.stacspec.org/v1.0.0-rc.1/multi-tenant-catalogs/transaction"
     )
     assert transaction_class in data["conformsTo"]
+
+
+def test_hide_alternate_parents_flag() -> None:
+    """Test that hide_alternate_parents flag is properly stored in app.state."""
+    settings = ApiSettings()
+    api = StacApi(
+        settings=settings,
+        client=DummyCoreClient(),
+        extensions=[
+            CatalogsExtension(
+                client=DummyCatalogsClient(),
+                settings=settings.model_dump(),
+                hide_alternate_parents=True,
+            ),
+        ],
+    )
+    assert hasattr(api.app.state, "catalogs_hide_alternate_parents")
+    assert api.app.state.catalogs_hide_alternate_parents is True
+
+
+def test_hide_alternate_parents_flag_default() -> None:
+    """Test that hide_alternate_parents defaults to False."""
+    settings = ApiSettings()
+    api = StacApi(
+        settings=settings,
+        client=DummyCoreClient(),
+        extensions=[
+            CatalogsExtension(
+                client=DummyCatalogsClient(),
+                settings=settings.model_dump(),
+            ),
+        ],
+    )
+    assert hasattr(api.app.state, "catalogs_hide_alternate_parents")
+    assert api.app.state.catalogs_hide_alternate_parents is False


### PR DESCRIPTION
Issue: #9 

Hide alternate parents flag. Alternate parents are presently advertised via "related" links, but the is some discussion on changing this: https://github.com/radiantearth/stac-spec/discussions/1374#discussioncomment-17141721